### PR TITLE
fix #1: `get_args` with nested generics on python 3.6

### DIFF
--- a/tests/test_typing_compat.py
+++ b/tests/test_typing_compat.py
@@ -5,6 +5,7 @@ import pytest
 from typingx import (
     Any,
     Callable,
+    Collection,
     Dict,
     FrozenSet,
     Generic,
@@ -83,6 +84,21 @@ class StrangePair(Generic[T, S]):
         (Callable[[], T][int], ([], int)),
         (Callable[[T], T][int], ([int], int)),
         (Callable[[T, float], U][int, str], ([int, float], str)),
+        (List[Collection[T]][int], (Collection[int],)),
+        (
+            Mapping[T, Sequence[U]][str, int],
+            (
+                str,
+                Sequence[int],
+            ),
+        ),
+        (
+            Mapping[str, Mapping[T, Collection[U]]][float, int],
+            (
+                str,
+                Mapping[float, Collection[int]],
+            ),
+        ),
     ],
 )
 def test_get_args(tp, expected_args):

--- a/typingx/__init__.py
+++ b/typingx/__init__.py
@@ -21,6 +21,7 @@ __all__ = (
     # typing, typing_extensions or own backport
     "Any",
     "Callable",
+    "Collection",
     "Dict",
     "FrozenSet",
     "Generic",

--- a/typingx/typing_compat.py
+++ b/typingx/typing_compat.py
@@ -35,7 +35,8 @@ if sys.version_info >= (3, 9):
 elif sys.version_info[:2] == (3, 8):
 
     def T_get_args(tp: TypeLike) -> T.Tuple[T.Any, ...]:
-        if tp is T.Callable:  # fallback since it fails on MacOS
+        # fallback for plain `Callable`, `Dict`, ... since it fails on MacOS
+        if tp in T.__dict__.values():
             return ()
         return T.get_args(tp)
 


### PR DESCRIPTION
closes #1